### PR TITLE
fix: Angular not liking JSON imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ coverage
 
 # Dist files
 dist
-src/version.json
+src/version.js

--- a/scripts/export-version-number.js
+++ b/scripts/export-version-number.js
@@ -1,4 +1,4 @@
 const { version } = require('../package.json')
 const fs = require('fs')
 
-fs.writeFileSync('./src/version.json', JSON.stringify({version}))
+fs.writeFileSync('./src/version.js', `export const version = ${JSON.stringify({version})}`)

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -1,5 +1,5 @@
 import TCGdex from './tcgdex'
-import { version } from './version.json'
+import { version } from './version'
 
 export default class Request {
 


### PR DESCRIPTION
Thanks to @timiliris for the report

It seems like Angular does not support import .json files so I moved to using a .js file made by the same script

```
../../TCGdex/javascript-sdk/dist/modules/Request.js:16:52-59 - Error: Should not import the named export 'version' (imported as 'version') from default-exporting module (only default export is available soon)
```
