### PR TITLE
feat: Add support for boosters to set and card

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -22,9 +22,18 @@ interface variants {
 	firstEdition?: boolean
 }
 
+interface booster {
+	id: string
+	name: string
+	logo?: string
+	artwork_front?: string
+	artwork_back?: string	
+}
+
 export type SetList = Array<SetResume>
 export type SerieList = Array<SerieResume>
 export type CardList = Array<CardResume>
+export type BoosterList = Array<booster>
 
 export interface SetResume {
 	id: string
@@ -105,6 +114,8 @@ export interface Set extends SetResume {
 	}
 
 	cards: CardList
+
+	boosters?: BoosterList
 }
 
 export interface CardResume {
@@ -302,6 +313,8 @@ export interface Card<SetType extends SetResume = SetResume> extends CardResume 
 		 */
 		expanded: boolean
 	}
+
+	boosters?: BoosterList
 }
 
 export type StringEndpointList = Array<string>

--- a/src/models/Card.ts
+++ b/src/models/Card.ts
@@ -1,5 +1,5 @@
 import CardResume from './CardResume'
-import type { Variants } from './Other'
+import type { Booster, Variants } from './Other'
 import type TCGdexSet from './Set'
 import type SetResume from './SetResume'
 
@@ -187,6 +187,8 @@ export default class Card extends CardResume {
 		 */
 		expanded: boolean
 	}
+
+	public boosters?: Array<Booster>
 
 	public override async getCard(): Promise<Card> {
 		return this

--- a/src/models/Other.d.ts
+++ b/src/models/Other.d.ts
@@ -4,3 +4,12 @@ export interface Variants {
 	holo?: boolean
 	firstEdition?: boolean
 }
+
+export interface Booster {
+
+	id: string
+	name: string
+	logo?: string
+	artwork_front?: string
+	artwork_back?: string
+}

--- a/src/models/Set.ts
+++ b/src/models/Set.ts
@@ -1,7 +1,7 @@
 import { objectLoop } from '@dzeio/object-util'
 import CardResume from './CardResume'
 import Model from './Model'
-import type { Variants } from './Other'
+import type { Booster, Variants } from './Other'
 import type SerieResume from './SerieResume'
 
 // biome-ignore lint/suspicious/noShadowRestrictedNames: <explanation>
@@ -69,6 +69,8 @@ export default class Set extends Model {
 	}
 
 	public cards!: Array<CardResume>
+
+	public boosters?: Array<Booster>
 
 	public async getSerie() {
 		return this.sdk.serie.get(this.serie.id)


### PR DESCRIPTION
feat: Add support for boosters to set and card

Add optional boosters fields to Set and Card now that they are available in the card DB.