### PR TITLE
Fix: Release date null for graphql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 test.ts
 coverage
+.idea
 
 # Dist files
 dist

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -12,7 +12,10 @@ export interface SerieResume {
 }
 
 export interface Serie extends SerieResume {
+	releaseDate?: string
 	sets: SetList
+	firstSet: SetResume
+	lastSet: SetResume
 }
 
 interface variants {

--- a/src/models/Serie.ts
+++ b/src/models/Serie.ts
@@ -5,12 +5,20 @@ import SetResume from './SetResume'
 
 export default class Serie extends SerieResume {
 	public sets!: Array<SetResume>
+	public firstSet?: SetResume
+	public lastSet?: SetResume
 
 	protected fill(obj: object): void {
 		objectLoop(obj, (value, key) => {
 			switch (key) {
 				case 'sets':
 					this.sets = (value as Array<any>).map((it) => Model.build(new SetResume(this.sdk), it))
+					break
+				case 'firstSet':
+					this.firstSet = Model.build(new SetResume(this.sdk), value)
+					break
+				case 'lastSet':
+					this.lastSet = Model.build(new SetResume(this.sdk), value)
 					break
 				default:
 					this[key] = value

--- a/src/models/SerieResume.ts
+++ b/src/models/SerieResume.ts
@@ -6,7 +6,7 @@ export default class SerieResume extends Model {
 	public id!: string
 	public name!: string
 	public logo?: string
-
+	public releaseDate?: string
 	/**
 	 * the the Card Image full URL
 	 *


### PR DESCRIPTION
Introduces optional releaseDate property to SerieResume and Serie interfaces and models. Adds firstSet and lastSet properties to Serie, updating fill logic to handle these fields. Also updates .gitignore to exclude .idea directory.
