### PR TITLE
fix: Extend SupportedLanguages list based on languages listed in cards-database

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -1,4 +1,6 @@
-export type SupportedLanguages = 'en' | 'fr' | 'es' | 'it' | 'pt' | 'de'
+export type SupportedLanguages = 'en' | 'fr' | 'es' | 'es-mx' | 'it' |
+	'pt' | 'pt-br' | 'de' | 'nl' | 'pl' | 'ru' |
+	'ja' | 'ko' | 'zh-tw' | 'id' | 'th' | 'zh-cn'
 
 /**
  * @deprecated This is not used anymore in the API V2


### PR DESCRIPTION
The TypeScript type `SupportedLanguages` was a bit out of sync with the languages available via the TCGdex API. Trying to use languages that are available but not defined in the type definition required type-checking opt-outs or `as unknown as SupportedLanguages` casts.

I updated the list with the languages defined here: https://github.com/tcgdex/cards-database/blob/master/server/compiler/index.ts
I did leave out `pt-pt` as it is completely empty. (Is it equivalent to "pt", Portuguese (Portugal)?)

Languages were sorted alphabetically but split between international and asia.

---

Maybe adding extra type definition for both those subsets that are then combined to `SupportedLanguages` could make sense but I don't see a use-case currently.
What would make sense would be an export of the languages list in JavaScript to be able to iterate over all available languages. But maybe not providing this is also good to discourage the idea. :-)

<!--
Thanks for your Pull Request, Please provide the related Issue using "Fix #0" or describe the change(s) you made.
The issue title must follow Conventional Commit (verified by Github Actions) conventionalcommits.org.
More informations at https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
-->
